### PR TITLE
chore: pin dependency versions (#1)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-liblistenbrainz
-python-dotenv
+liblistenbrainz==0.6.1
+python-dotenv==1.2.1


### PR DESCRIPTION
## Summary
- Pin `liblistenbrainz==0.6.1` and `python-dotenv==1.2.1` in `requirements.txt`
- Prevents supply-chain risks from unpinned dependencies pulling unexpected versions

## Test Plan
- [ ] `pip install -r requirements.txt` installs the expected versions
- [ ] Script runs normally with `--dry-run`

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated and pinned dependency versions to ensure consistent builds and improved stability across all environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->